### PR TITLE
Improvements to docs + API tweaks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -198,7 +198,7 @@ doc_home = os.path.abspath(os.path.dirname(__file__))
 # WARNING: The config value `apidoc_module_dir' has type `unicode', expected to ['str'].
 apidoc_module_dir = os.path.join(doc_home, "..", "entente").encode('utf-8')
 apidoc_output_dir = os.path.join(doc_home, "api")
-apidoc_excluded_paths = ["**/test_*.py"]
+apidoc_excluded_paths = ["test_*"]
 apidoc_separate_modules = True
 
 # It's not possible to configure --no-toc in sphinxcontrib-apidoc. This

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -196,7 +196,7 @@ autosummary_generate = True
 doc_home = os.path.abspath(os.path.dirname(__file__))
 # .encode() to avoid
 # WARNING: The config value `apidoc_module_dir' has type `unicode', expected to ['str'].
-apidoc_module_dir = os.path.join(doc_home, "..", "entente").encode('utf-8')
+apidoc_module_dir = os.path.join(doc_home, "..", "entente").encode("utf-8")
 apidoc_output_dir = os.path.join(doc_home, "api")
 apidoc_excluded_paths = ["test_*"]
 apidoc_separate_modules = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -194,7 +194,9 @@ autosummary_generate = True
 # https://github.com/sphinx-contrib/apidoc
 # https://github.com/rtfd/readthedocs.org/issues/1139
 doc_home = os.path.abspath(os.path.dirname(__file__))
-apidoc_module_dir = os.path.join(doc_home, "..", "entente")
+# .encode() to avoid
+# WARNING: The config value `apidoc_module_dir' has type `unicode', expected to ['str'].
+apidoc_module_dir = os.path.join(doc_home, "..", "entente").encode('utf-8')
 apidoc_output_dir = os.path.join(doc_home, "api")
 apidoc_excluded_paths = ["**/test_*.py"]
 apidoc_separate_modules = True

--- a/entente/cgal_search.py
+++ b/entente/cgal_search.py
@@ -1,24 +1,22 @@
 """
-`cgal_search` provides spatial search on vertices and faces. This is
-implemented atop [CGAL's axis-aligned-bounding-box search tree][aabb].
+`cgal_search` provides spatial search for vertices and faces. This is
+implemented atop `CGAL's axis-aligned-bounding-box search tree
+<https://doc.cgal.org/latest/AABB_tree/index.html>`_.
 
-[CGAL][] is a heavy dependency and therefore is optional. Before using this
-module, you must install CGAL and its Python bindings (which take quite some
-time to build).
+`CGAL <https://www.cgal.org/>`_ is a heavy dependency and therefore is
+optional. Before using this module, you must install CGAL and its Python
+bindings (which take quite some time to build).
 
 On Mac OS:
 
-    ```sh
+.. code-block:: sh
+
     brew install cgal swig
     pip install cgal-bindings
-    # wait a year
-    ```
+    # wait approximately one year
 
-Note: The AABB tree is in the [GPLv3-licensed portion of CGAL][cgal license].
-
-[aabb]: https://doc.cgal.org/latest/AABB_tree/index.html
-[cgal]: https://www.cgal.org/
-[cgal license]: https://www.cgal.org/license.html
+Note: The AABB tree is in the `GPLv3-licensed portion of CGAL
+<https://www.cgal.org/license.html>`_
 """
 from __future__ import print_function
 
@@ -55,16 +53,15 @@ def create_aabb_tree(mesh):
     """
     Create a CGAL AABB tree from the given mesh.
 
-    These trees may rely on some shared internal storage in CGAL, so to be
-    conservative, *finish using one before creating another*.
+    Reports suggest trees may rely on some shared internal storage in CGAL, so
+    to be conservative, *finish using one before creating another*.
 
-    For more information, see:
-
-    - https://doc.cgal.org/latest/AABB_tree/index.html
-    - https://github.com/CGAL/cgal-swig-bindings/blob/master/examples/python/AABB_triangle_3_example.py
+    See also:
+        - https://doc.cgal.org/latest/AABB_tree/index.html
+        - https://github.com/CGAL/cgal-swig-bindings/blob/master/examples/python/AABB_triangle_3_example.py
 
     Returns:
-        CGAL_AABB_tree: A CGAL AABB tree.
+        CGAL.CGAL_AABB_tree: A CGAL AABB tree.
     """
     from CGAL.CGAL_Kernel import Point_3, Triangle_3
     from CGAL.CGAL_AABB_tree import AABB_tree_Triangle_3_soup
@@ -84,16 +81,16 @@ def faces_nearest_to_points(mesh, query_points, ret_points=False):
     points.
 
     Args:
-        query_points (arraylike): The points to query, with shape kx3
+        query_points (np.arraylike): The points to query, with shape `kx3`
         ret_points (bool): When `True`, return both the indices of the
             nearest faces and the closest points to the query points, which
             are not necessarily vertices. When `False`, return only the
             face indices.
 
     Returns:
-        object: np.ndarray with shape kx1 of face indices, or when `ret_points`
-        is `True`, a tuple which also contains a np.ndarray with shape kx3 with
-        the coordinates of the closest points.
+        object: face indices as `kx1 np.ndarray`, or when `ret_points`
+        is `True`, a tuple also including the coordinates of the closest points
+        as `kx3 np.ndarray`.
     """
     import numpy as np
     from CGAL.CGAL_Kernel import Point_3

--- a/entente/cgal_search.py
+++ b/entente/cgal_search.py
@@ -1,16 +1,32 @@
-def require_cgal():
-    """
-    Check that CGAL is installed, and exit with a helpful error message
-    if it is not. CGAL is optional because it is a very heavy dependency.
-    """
-    message = """
-    CGAL is not installed.
+"""
+`cgal_search` provides spatial search on vertices and faces. This is
+implemented atop [CGAL's axis-aligned-bounding-box search tree][aabb].
 
+[CGAL][] is a heavy dependency and therefore is optional. Before using this
+module, you must install CGAL and its Python bindings (which take quite some
+time to build).
+
+On Mac OS:
+
+    ```sh
     brew install cgal swig
     pip install cgal-bindings
-    wait a year
+    # wait a year
+    ```
 
-    Note: CGAL has a GPLv3 license.
+Note: The AABB tree is in the [GPLv3-licensed portion of CGAL][cgal license].
+
+[aabb]: https://doc.cgal.org/latest/AABB_tree/index.html
+[cgal]: https://www.cgal.org/
+[cgal license]: https://www.cgal.org/license.html
+"""
+from __future__ import print_function
+
+
+def require_cgal():
+    """
+    Check that CGAL is installed, and raise an error with a helpful error message
+    if it is not.
     """
     try:
         from CGAL.CGAL_Kernel import Point_3, Triangle_3
@@ -21,10 +37,35 @@ def require_cgal():
         assert Triangle_3
         assert AABB_tree_Triangle_3_soup
     except ImportError:
-        raise ImportError(message)
+        print(
+            """
+            CGAL is not installed. On Mac OS:
+
+            $ brew install cgal swig
+            $ pip install cgal-bindings
+            $ wait a year
+
+            Note: The AABB code in CGAL has a GPLv3 license.
+            """
+        )
+        raise ImportError("CGAL is not installed")
 
 
 def create_aabb_tree(mesh):
+    """
+    Create a CGAL AABB tree from the given mesh.
+
+    These trees may rely on some shared internal storage in CGAL, so to be
+    conservative, *finish using one before creating another*.
+
+    For more information, see:
+
+    - https://doc.cgal.org/latest/AABB_tree/index.html
+    - https://github.com/CGAL/cgal-swig-bindings/blob/master/examples/python/AABB_triangle_3_example.py
+
+    Returns:
+        CGAL_AABB_tree: A CGAL AABB tree.
+    """
     from CGAL.CGAL_Kernel import Point_3, Triangle_3
     from CGAL.CGAL_AABB_tree import AABB_tree_Triangle_3_soup
 
@@ -37,15 +78,31 @@ def create_aabb_tree(mesh):
     return tree
 
 
-def faces_nearest_to_points(mesh, to_points, ret_points=False):
+def faces_nearest_to_points(mesh, query_points, ret_points=False):
+    """
+    Find the triangular faces on a mesh which are nearest to the given query
+    points.
+
+    Args:
+        query_points (arraylike): The points to query, with shape kx3
+        ret_points (bool): When `True`, return both the indices of the
+            nearest faces and the closest points to the query points, which
+            are not necessarily vertices. When `False`, return only the
+            face indices.
+
+    Returns:
+        object: np.ndarray with shape kx1 of face indices, or when `ret_points`
+        is `True`, a tuple which also contains a np.ndarray with shape kx3 with
+        the coordinates of the closest points.
+    """
     import numpy as np
     from CGAL.CGAL_Kernel import Point_3
 
     tree = create_aabb_tree(mesh)
-    face_indices = np.empty(shape=(len(to_points),), dtype=np.uint64)
+    face_indices = np.empty(shape=(len(query_points),), dtype=np.uint64)
     if ret_points:
-        closest_points = np.empty(shape=(len(to_points), 3))
-    for i, p in enumerate(to_points):
+        closest_points = np.empty(shape=(len(query_points), 3))
+    for i, p in enumerate(query_points):
         point, face_index = tree.closest_point_and_primitive(Point_3(*p))
         face_indices[i] = face_index
         if ret_points:

--- a/entente/cli.py
+++ b/entente/cli.py
@@ -1,5 +1,9 @@
 """
+Example usage:
+
+```sh
 python -m entente.cli examples/vitra/vitra.obj examples/vitra/vitra.pp examples/vitra/vitra_stretched.obj
+```
 """
 
 import click

--- a/entente/cli.py
+++ b/entente/cli.py
@@ -3,9 +3,11 @@ Command line for invoking utilities in this library.
 
 Example:
 
-    ```sh
-    python -m entente.cli examples/vitra/vitra.obj examples/vitra/vitra.pp examples/vitra/vitra_stretched.obj
-    ```
+    .. code-block:: sh
+
+        python -m entente.cli examples/vitra/vitra.obj examples/vitra/vitra.pp \\
+            examples/vitra/vitra_stretched.obj
+
 """
 
 import click

--- a/entente/cli.py
+++ b/entente/cli.py
@@ -1,9 +1,11 @@
 """
-Example usage:
+Command line for invoking utilities in this library.
 
-```sh
-python -m entente.cli examples/vitra/vitra.obj examples/vitra/vitra.pp examples/vitra/vitra_stretched.obj
-```
+Example:
+
+    ```sh
+    python -m entente.cli examples/vitra/vitra.obj examples/vitra/vitra.pp examples/vitra/vitra_stretched.obj
+    ```
 """
 
 import click

--- a/entente/equality.py
+++ b/entente/equality.py
@@ -1,4 +1,17 @@
 def attr_has_same_shape(first_obj, second_obj, attr):
+    """
+    Given two objects, check if the given arraylike attributes of those
+    objects have the same shape. If one object has an attribute value of
+    `None`, the other must too.
+
+    Args:
+        first_obj (obj): A object with an arraylike `attr` attribute.
+        second_obj (obj): Another object with an arraylike `attr` attribute.
+        attr (str): The name of the attribute to test.
+
+    Returns:
+        bool: `True` if attributes are the same shape
+    """
     first, second = getattr(first_obj, attr), getattr(second_obj, attr)
     if first is None or second is None:
         return first is second
@@ -7,6 +20,19 @@ def attr_has_same_shape(first_obj, second_obj, attr):
 
 
 def attr_is_equal(first_obj, second_obj, attr):
+    """
+    Given two objects, check if the given arraylike attributes of those
+    objects are equal. If one object has an attribute value of `None`, the
+    other must too.
+
+    Args:
+        first_obj (obj): A object with an arraylike `attr` attribute.
+        second_obj (obj): Another object with an arraylike `attr` attribute.
+        attr (str): The name of the attribute to test.
+
+    Returns:
+        bool: `True` if attributes are equal
+    """
     import numpy as np
 
     # Avoid comparing None's.
@@ -16,6 +42,18 @@ def attr_is_equal(first_obj, second_obj, attr):
 
 
 def have_same_topology(first_mesh, second_mesh):
+    """
+    Given two meshes, check if they have the same vertex count and same faces.
+    In other words, check if they have the same topology.
+
+
+    Args:
+        first_mesh (lace.mesh.Mesh): A mesh.
+        second_mesh (lace.mesh.Mesh): Another mesh.
+
+    Returns:
+        bool: `True` if meshes have the same topology
+    """
     return attr_has_same_shape(first_mesh, second_mesh, "v") and attr_is_equal(
         first_mesh, second_mesh, "f"
     )

--- a/entente/equality.py
+++ b/entente/equality.py
@@ -2,6 +2,7 @@
 Utilities related to mesh equality.
 """
 
+
 def attr_has_same_shape(first_obj, second_obj, attr):
     """
     Given two objects, check if the given arraylike attributes of those

--- a/entente/equality.py
+++ b/entente/equality.py
@@ -1,12 +1,16 @@
+"""
+Utilities related to mesh equality.
+"""
+
 def attr_has_same_shape(first_obj, second_obj, attr):
     """
     Given two objects, check if the given arraylike attributes of those
     objects have the same shape. If one object has an attribute value of
-    `None`, the other must too.
+    ``None``, the other must too.
 
     Args:
-        first_obj (obj): A object with an arraylike `attr` attribute.
-        second_obj (obj): Another object with an arraylike `attr` attribute.
+        first_obj (obj): A object with an arraylike ``attr`` attribute.
+        second_obj (obj): Another object with an arraylike ``attr`` attribute.
         attr (str): The name of the attribute to test.
 
     Returns:
@@ -22,7 +26,7 @@ def attr_has_same_shape(first_obj, second_obj, attr):
 def attr_is_equal(first_obj, second_obj, attr):
     """
     Given two objects, check if the given arraylike attributes of those
-    objects are equal. If one object has an attribute value of `None`, the
+    objects are equal. If one object has an attribute value of ``None``, the
     other must too.
 
     Args:
@@ -45,7 +49,6 @@ def have_same_topology(first_mesh, second_mesh):
     """
     Given two meshes, check if they have the same vertex count and same faces.
     In other words, check if they have the same topology.
-
 
     Args:
         first_mesh (lace.mesh.Mesh): A mesh.

--- a/entente/geometry.py
+++ b/entente/geometry.py
@@ -1,3 +1,7 @@
+"""
+Functions relating to mesh geometry.
+"""
+
 def compute_barycentric_coordinates(vertices_of_tris, points):
     """
     Compute barycentric coordinates for the projection of a set of points to a
@@ -5,25 +9,25 @@ def compute_barycentric_coordinates(vertices_of_tris, points):
 
     These barycentric coordinates can refer to points outside the triangle.
     This happens when one of the coordinates is negative. However they can't
-    specify points outside the triangle's plane. That requires tetrahedral
-    coordinates.
+    specify points outside the triangle's plane. (That requires tetrahedral
+    coordinates.)
 
     The returned coordinates supply a linear combination which, applied to the
     vertices, returns the projection of the original point the plane of the
     triangle.
 
     Args:
-        vertices_of_tris (arraylike): A set of triangle vertices with shape kx3x3.
-        points (arraylike): Coordinates of points with shape kx3.
+        vertices_of_tris (np.arraylike): A set of triangle vertices as `kx3x3`.
+        points (np.arraylike): Coordinates of points as `kx3`.
 
     Returns:
-        np.ndarray: with shape kx3
+        np.ndarray: Barycentric coordinates as `kx3`
 
     See Also:
         https://en.wikipedia.org/wiki/Barycentric_coordinate_system
 
-    Todo:
-        A function with this signature probably belongs in blmath.
+    Note:
+        A function with this signature probably belongs in `blmath`.
     """
     from blmath.geometry.barycentric import barycentric_coordinates_of_projection
     from .validation import validate_shape_from_ns

--- a/entente/geometry.py
+++ b/entente/geometry.py
@@ -1,20 +1,29 @@
 def compute_barycentric_coordinates(vertices_of_tris, points):
     """
-    Compute barycentric coordinates for the projection of a set of points
-    (specified as kx3) to a given set of triangles (specified by their
-    vertices as kx3x3).
+    Compute barycentric coordinates for the projection of a set of points to a
+    given set of triangles specfied by their vertices.
 
-    These barycentric coordinates, can refer to points outside the triangle.
+    These barycentric coordinates can refer to points outside the triangle.
     This happens when one of the coordinates is negative. However they can't
-    specify points outside the triangle's plane.
+    specify points outside the triangle's plane. That requires tetrahedral
+    coordinates.
 
-    https://en.wikipedia.org/wiki/Barycentric_coordinate_system
+    The returned coordinates supply a linear combination which, applied to the
+    vertices, returns the projection of the original point the plane of the
+    triangle.
 
-    The returned coordinates supply a kx3 linear combination which, applied
-    to the vertices, returns the original point projected to the plane of
-    the triangle.
+    Args:
+        vertices_of_tris (arraylike): A set of triangle vertices with shape kx3x3.
+        points (arraylike): Coordinates of points with shape kx3.
 
-    A function with this signature probably belongs in blmath.
+    Returns:
+        np.ndarray: with shape kx3
+
+    See Also:
+        https://en.wikipedia.org/wiki/Barycentric_coordinate_system
+
+    Todo:
+        A function with this signature probably belongs in blmath.
     """
     from blmath.geometry.barycentric import barycentric_coordinates_of_projection
     from .validation import validate_shape_from_ns

--- a/entente/geometry.py
+++ b/entente/geometry.py
@@ -32,7 +32,7 @@ def compute_barycentric_coordinates(vertices_of_tris, points):
     from blmath.geometry.barycentric import barycentric_coordinates_of_projection
     from .validation import validate_shape_from_ns
 
-    k = validate_shape_from_ns(locals(), "vertices_of_tris", "*", 3, 3)
+    k = validate_shape_from_ns(locals(), "vertices_of_tris", -1, 3, 3)
     validate_shape_from_ns(locals(), "points", k, 3)
 
     return barycentric_coordinates_of_projection(

--- a/entente/geometry.py
+++ b/entente/geometry.py
@@ -2,6 +2,7 @@
 Functions relating to mesh geometry.
 """
 
+
 def compute_barycentric_coordinates(vertices_of_tris, points):
     """
     Compute barycentric coordinates for the projection of a set of points to a

--- a/entente/landmarks.py
+++ b/entente/landmarks.py
@@ -19,6 +19,7 @@ class Landmarker(object):
         landmarks (dict): A mapping of landmark names to the points, which are
             `3x1` arraylike objects.
     """
+
     def __init__(self, source_mesh, landmarks):
         from cgal_search import require_cgal
 
@@ -93,5 +94,5 @@ class Landmarker(object):
         from .equality import have_same_topology
 
         if not have_same_topology(self.source_mesh, target):
-            raise ValueError('Target mesh must have the same topology')
+            raise ValueError("Target mesh must have the same topology")
         return self._invoke_regressor(target)

--- a/entente/landmarks.py
+++ b/entente/landmarks.py
@@ -1,7 +1,24 @@
+"""
+Functions for transferring landmarks from one mesh to another.
+
+This module requires CGAL. See note in ``entente.cgal_search``.
+"""
+
 from cached_property import cached_property
 
 
 class Landmarker(object):
+    """
+    An object which encapsulates a source mesh and a set of landmarks on that
+    mesh. Its function is to transfer those landmarks onto a new mesh.
+
+    The resultant landmarks will always be on or near the surface of the mesh.
+
+    Args:
+        source_mesh (lace.mesh.Mesh): The source mesh
+        landmarks (dict): A mapping of landmark names to the points, which are
+            `3x1` arraylike objects.
+    """
     def __init__(self, source_mesh, landmarks):
         from cgal_search import require_cgal
 
@@ -11,6 +28,14 @@ class Landmarker(object):
 
     @classmethod
     def load(cls, source_mesh_path, landmark_path):
+        """
+        Create a landmarker using the given paths to a source mesh and landmarks.
+
+        Args:
+            source_mesh_path (str): File path to the source mesh.
+            landmark_path (str): File path to a meshlab ``.pp`` file containing
+                the landmark points.
+        """
         from lace.mesh import Mesh
         from lace.serialization import meshlab_pickedpoints
 
@@ -20,7 +45,7 @@ class Landmarker(object):
         )
 
     @cached_property
-    def regressor(self):
+    def _regressor(self):
         import numpy as np
         from blmath.numerics.matlab import sparse
         from .geometry import compute_barycentric_coordinates
@@ -50,15 +75,23 @@ class Landmarker(object):
             3 * self.source_mesh.v.shape[0],
         )
 
-    def invoke_regressor(self, target):
-        coords = self.regressor * target.v.reshape(-1)
+    def _invoke_regressor(self, target):
+        coords = self._regressor * target.v.reshape(-1)
         return dict(zip(self.landmarks.keys(), coords.reshape(-1, 3)))
 
     def transfer_landmarks_onto(self, target):
+        """
+        Transfer landmarks onto the given target mesh, which must be in the same
+        topology as the source mesh.
+
+        Args:
+            target (lace.mesh.Mesh): Target mesh
+
+        Returns:
+            dict: A mapping of landmark names to a np.ndarray with shape `3x1`.
+        """
         from .equality import have_same_topology
 
         if not have_same_topology(self.source_mesh, target):
-            # raise ValueError('Target mesh must have the same topology')
-            target.f = self.source_mesh.f
-            target.ft = self.source_mesh.ft
-        return self.invoke_regressor(target)
+            raise ValueError('Target mesh must have the same topology')
+        return self._invoke_regressor(target)

--- a/entente/validation.py
+++ b/entente/validation.py
@@ -1,17 +1,23 @@
 def validate_shape(a, *shape, **kwargs):
     """
+    Check that the given argument has the expected shape. Shape dimensions can
+    be ints or -1 for a wildcard. The wildcard dimensions are returned, which
+    allows them to be used for subsequent validation or elsewhere in the
+    function.
+
     Args:
-        a: An array-like input.
-        shape (tuple): Shape to validate. To require 3 by 1, pass (3,). To
-            require n by 3, pass (-1, 3). Pass '*' for a wildcard dimension.
+        a (np.arraylike): An array-like input.
+        shape (list): Shape to validate. To require 3 by 1, pass `3`. To
+            require n by 3, pass `-1, 3`.
         name (str): Variable name to embed in the error message.
 
     Returns:
-        object: The wildcard dimension or a tuple of wildcard dimensions.
+        object: The wildcard dimension (if one) or a tuple of wildcard
+        dimensions (if more than one).
     """
-    is_wildcard = lambda dim: dim == "*"
+    is_wildcard = lambda dim: dim == -1
     if all(not isinstance(dim, int) and not is_wildcard(dim) for dim in shape):
-        raise ValueError("Expected shape dimensions to be int or '*'")
+        raise ValueError("Expected shape dimensions to be int")
 
     if "name" in kwargs:
         preamble = "{} must be an array".format(kwargs["name"])
@@ -48,7 +54,22 @@ def validate_shape(a, *shape, **kwargs):
 
 def validate_shape_from_ns(namespace, name, *shape):
     """
-    Convenience function.
-    Usage: validate_shape_from_namespace(locals(), 'points', '*', 3)
+    Convenience function for invoking `validate_shape()` with a `locals()`
+    dict.
+
+    Args:
+        namespace (dict): A subscriptable object, typically `locals()`.
+        name (str): Key to pull from `namespace`.
+        shape (list): Shape to validate. To require 3 by 1, pass `3`. To
+            require n by 3, pass `-1, 3`.
+
+    Returns:
+        object: The wildcard dimension (if one) or a tuple of wildcard
+        dimensions (if more than one).
+
+    Example:
+
+        validate_shape_from_namespace(locals(), 'points', -1, 3)
+
     """
     return validate_shape(namespace[name], *shape, name=name)


### PR DESCRIPTION
- entente.cgal_search.faces_nearest_to_points: Rename argument `to_points` to
  `search_points`.
- entente.validation.validate_shape_from_ns: Wildcard arguments are now
  specified using `-1` instead of `'*'`.
- entente.landmarks.Landmarker: Make private `invoke_regressor` and
  `regressor`.