### PR TITLE
Clean up in dev script

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python
 
+import os
 import click
-import glob
 from executor import execute
+
+
+def nose_cmd():
+    # More reliably locate this command when more than one Python are
+    # installed.
+    try:
+        execute("nose2-2.7 --help", capture=True)
+        return "nose2-2.7"
+    except:
+        return "nose2"
+
+
+def python_source_files():
+    import glob
+
+    return glob.glob("*.py") + ["entente/", "doc/"]
 
 
 @click.group()
@@ -50,25 +66,22 @@ def docker_push(tag):
 
 @cli.command()
 def test():
-    execute("nose2")
-
-
-source_files = glob.glob("*.py") + ["entente/", "doc/"]
+    execute(nose_cmd())
 
 
 @cli.command()
 def lint():
-    execute("pyflakes", *source_files)
+    execute("pyflakes", *python_source_files())
 
 
 @cli.command()
 def black():
-    execute("black", *source_files)
+    execute("black", *python_source_files())
 
 
 @cli.command()
 def black_check():
-    execute("black", "--check", *source_files)
+    execute("black", "--check", *python_source_files())
 
 
 @cli.command()
@@ -90,4 +103,5 @@ def upload():
 
 
 if __name__ == "__main__":
+    os.chdir(os.path.abspath(os.path.dirname(__file__)))
     cli()


### PR DESCRIPTION
- Make a bit safer with os.chdir
- Work well when multiple pythons are installed on MacOS