### PR TITLE
restore_correspondence: Rework and improve

### DIFF
--- a/entente/restore_correspondence.py
+++ b/entente/restore_correspondence.py
@@ -7,17 +7,24 @@ def _maybe_tqdm(iterable, progress):
         return iterable
 
 
-def find_permutation(a, b, progress=True):
+def find_correspondence(a, b, atol=1e-4, allow_unmatched=False, ret_unmatched_b=False, progress=True):
     """
-    Given a `kxn` array `a` and its permutation `b`, order the indices of `a`
-    such that `a[find_permutation(a, b)]` is equal to `b`.
+    Given a `kxn` array `a[0], a[1], ...` and `jxn` array `b[0], b[1], ...`,
+    for each element in `a`, find the index of `b` with the corresponding
+    element.
 
-    The permutation must be along the first axis, such that `a[0], a[1], ...`
-    and `b[0], b[1], ...` have the same elements.
+    When `allow_unmatched` is `True`, return an index of `-1` for elements in
+    `a` having no match in `b`. When `False`, the default, `a` and `b` must
+    contain the same set of elements and `b[find_correspondence(a, b)]` will
+    equal `a`.
 
     Args:
-        a (np.arraylike): `kxn` array
-        b (np.arraylike): `kxn` array
+        a (np.arraylike): `kxn` array.
+        b (np.arraylike): `jxn` array.
+        atol (float): Match tolerance.
+        allow_unmatched (bool): When `True`
+        ret_unmatched_b (bool): When `True`, return a tuple which also contains
+            the indices of `b` which were not matched.
         progress (bool): When `True`, show a progress bar.
 
     Return:
@@ -25,43 +32,51 @@ def find_permutation(a, b, progress=True):
 
     Note:
         This relies on a brute-force algorithm.
+
+        For the interpretation of `atol`, see documentation for `np.isclose`.
     """
     import numpy as np
 
-    if not len(a) == len(b):
-        raise
+    if not len(a) == len(b) and not allow_unmatched:
+        raise ValueError("a and b do not contain the same number of elements")
 
-    a_remaining = np.ones(len(a), dtype=np.bool_)
-    a_to_b = np.zeros(len(a), dtype=np.uint64)
+    a_to_b = np.repeat(-1, len(a))
+    b_matched = np.zeros(len(b), dtype=np.bool_)
 
-    for i, item in _maybe_tqdm(enumerate(b), progress):
-        indices, = np.nonzero(np.logical_not(a - item).all(axis=1))
-        if len(indices) != 1:
+    for a_index, item in _maybe_tqdm(enumerate(a), progress):
+        indices, = np.nonzero(np.all(np.isclose(b, item, atol=atol), axis=1))
+        if len(indices) >= 1:
+            b_index = indices[0]
+            b_matched[b_index] = True
+            a_to_b[a_index] = b_index
+        elif not allow_unmatched:
             raise ValueError(
-                "Couldn't find corresponding element in a for item {} in b".format(i)
+                "Couldn't find corresponding element in b for item {} in a".format(a_index)
             )
-        index = indices[0]
-        a_remaining[index] = 0
-        a_to_b[i] = index
 
-    return a_to_b
+    if ret_unmatched_b:
+        unmatched_b, = np.where(b_matched == 0)
+        return a_to_b, unmatched_b
+    else:
+        return a_to_b
 
 
-def restore_correspondence(mesh, reference_mesh, progress=True):
+def restore_correspondence(shuffled_mesh, reference_mesh, atol=1e-4, progress=True):
     """
-    Given `mesh` which has the same vertex set as a given `reference_mesh`,
-    but which has lost its correspondence due to the vertices being shuffled,
-    reorder the vertices in `mesh` so they match the order in
-    `reference_mesh`.
+    Given a reference mesh, reorder the vertices of a shuffled copy to restore
+    correspondence with the reference mesh. The vertex set of the shuffled
+    mesh and reference mesh must be the same within `atol`. Mutates
+    `reference_mesh`. Faces are preserved but ignored.
 
     Args:
-        mesh (lace.mesh.Mesh): A mesh, which will be mutated
-        reference_mesh (lace.mesh.Mesh): Another mesh with the same set of
-            vertices in the desired order
+        reference_mesh (lace.mesh.Mesh): A mesh with the vertices in the
+            desired order.
+        shuffled_mesh (lace.mesh.Mesh): A mesh with the same vertex set as
+            `reference_mesh`.
         progress (bool): When `True`, show a progress bar.
 
     Returns:
-        np.ndarray: `vx1` mapping of old face indices to new
+        np.ndarray: `vx1` which maps old vertices in `shuffled_mesh` to new.
 
     Note:
         This was designed to assist in extracting face ordering and groups from a
@@ -69,6 +84,6 @@ def restore_correspondence(mesh, reference_mesh, progress=True):
 
         It relies on a brute-force algorithm.
     """
-    v_old_to_new = find_permutation(reference_mesh.v, mesh.v, progress=progress)
-    mesh.reorder_vertices(v_old_to_new)
+    v_old_to_new = find_correspondence(shuffled_mesh.v, reference_mesh.v, atol=atol, progress=progress)
+    shuffled_mesh.reorder_vertices(v_old_to_new)
     return v_old_to_new

--- a/entente/restore_correspondence.py
+++ b/entente/restore_correspondence.py
@@ -7,7 +7,9 @@ def _maybe_tqdm(iterable, progress):
         return iterable
 
 
-def find_correspondence(a, b, atol=1e-4, allow_unmatched=False, ret_unmatched_b=False, progress=True):
+def find_correspondence(
+    a, b, atol=1e-4, allow_unmatched=False, ret_unmatched_b=False, progress=True
+):
     """
     Given a `kxn` array `a[0], a[1], ...` and `jxn` array `b[0], b[1], ...`,
     for each element in `a`, find the index of `b` with the corresponding
@@ -51,7 +53,9 @@ def find_correspondence(a, b, atol=1e-4, allow_unmatched=False, ret_unmatched_b=
             a_to_b[a_index] = b_index
         elif not allow_unmatched:
             raise ValueError(
-                "Couldn't find corresponding element in b for item {} in a".format(a_index)
+                "Couldn't find corresponding element in b for item {} in a".format(
+                    a_index
+                )
             )
 
     if ret_unmatched_b:
@@ -84,6 +88,8 @@ def restore_correspondence(shuffled_mesh, reference_mesh, atol=1e-4, progress=Tr
 
         It relies on a brute-force algorithm.
     """
-    v_old_to_new = find_correspondence(shuffled_mesh.v, reference_mesh.v, atol=atol, progress=progress)
+    v_old_to_new = find_correspondence(
+        shuffled_mesh.v, reference_mesh.v, atol=atol, progress=progress
+    )
     shuffled_mesh.reorder_vertices(v_old_to_new)
     return v_old_to_new

--- a/entente/restore_correspondence.py
+++ b/entente/restore_correspondence.py
@@ -8,23 +8,23 @@ def _maybe_tqdm(iterable, progress):
 
 
 def find_correspondence(
-    a, b, atol=1e-4, allow_unmatched=False, ret_unmatched_b=False, progress=True
+    a, b, atol=1e-4, elements_must_match=True, ret_unmatched_b=False, progress=True
 ):
     """
-    Given a `kxn` array `a[0], a[1], ...` and `jxn` array `b[0], b[1], ...`,
-    for each element in `a`, find the index of `b` with the corresponding
-    element.
+    Given `a[0], a[1], ..., a[k]` and `b[0], b[1], ..., b[j]`, find the index
+    of `b` which corresponds to each element of `a`.
 
-    When `allow_unmatched` is `True`, return an index of `-1` for elements in
-    `a` having no match in `b`. When `False`, the default, `a` and `b` must
+    When `elements_must_match` is `True`, the default, `a` and `b` must
     contain the same set of elements and `b[find_correspondence(a, b)]` will
-    equal `a`.
+    equal `a`. Otherwise, return `-1` for elements in `a` having no match in
+    `b`.
 
     Args:
         a (np.arraylike): `kxn` array.
         b (np.arraylike): `jxn` array.
         atol (float): Match tolerance.
-        allow_unmatched (bool): When `True`
+        elements_must_match (bool): When `True`, `a` and `b` must contain the
+            same elements.
         ret_unmatched_b (bool): When `True`, return a tuple which also contains
             the indices of `b` which were not matched.
         progress (bool): When `True`, show a progress bar.
@@ -39,7 +39,7 @@ def find_correspondence(
     """
     import numpy as np
 
-    if not len(a) == len(b) and not allow_unmatched:
+    if elements_must_match and len(a) != len(b):
         raise ValueError("a and b do not contain the same number of elements")
 
     a_to_b = np.repeat(-1, len(a))
@@ -51,7 +51,7 @@ def find_correspondence(
             b_index = indices[0]
             b_matched[b_index] = True
             a_to_b[a_index] = b_index
-        elif not allow_unmatched:
+        elif elements_must_match:
             raise ValueError(
                 "Couldn't find corresponding element in b for item {} in a".format(
                     a_index

--- a/entente/restore_correspondence.py
+++ b/entente/restore_correspondence.py
@@ -12,11 +12,11 @@ def find_correspondence(
 ):
     """
     Given `a[0], a[1], ..., a[k]` and `b[0], b[1], ..., b[j]`, match each element
-    of `a` to the corresponding element in `b`.
+    of `a` to the corresponding element of `b`.
 
-    When `all_must_match` is `True`, the default, `a` and `b` must contain the
-    same set of elements, and in that case, `b[find_correspondence(a, b)]`
-    will equal `a`. Otherwise, return `-1` for elements with no match in `b`.
+    When `all_must_match` is `True` `a` and `b` must contain the same set of
+    elements. `b[find_correspondence(a, b)]` equals `a`. Otherwise, return
+    `-1` for elements with no match in `b`.
 
     Args:
         a (np.arraylike): `kxn` array.
@@ -68,8 +68,8 @@ def restore_correspondence(shuffled_mesh, reference_mesh, atol=1e-4, progress=Tr
     """
     Given a reference mesh, reorder the vertices of a shuffled copy to restore
     correspondence with the reference mesh. The vertex set of the shuffled
-    mesh and reference mesh must be the same within `atol`. Mutates
-    `reference_mesh`. Faces are preserved but ignored.
+    mesh and reference mesh must be equal within `atol`. Mutate
+    `reference_mesh`. Ignore faces but preserves their integrity.
 
     Args:
         reference_mesh (lace.mesh.Mesh): A mesh with the vertices in the

--- a/entente/restore_correspondence.py
+++ b/entente/restore_correspondence.py
@@ -83,7 +83,8 @@ def restore_correspondence(shuffled_mesh, reference_mesh, atol=1e-4, progress=Tr
 
     Note:
         This was designed to assist in extracting face ordering and groups from a
-        shuffled `mesh` that "work" with `reference_mesh`.
+        `shuffled_mesh` that "work" with `reference_mesh`, so the face ordering
+        and groups can be used with different vertices.
 
         It relies on a brute-force algorithm.
     """

--- a/entente/restore_correspondence.py
+++ b/entente/restore_correspondence.py
@@ -8,22 +8,21 @@ def _maybe_tqdm(iterable, progress):
 
 
 def find_correspondence(
-    a, b, atol=1e-4, elements_must_match=True, ret_unmatched_b=False, progress=True
+    a, b, atol=1e-4, all_must_match=True, ret_unmatched_b=False, progress=True
 ):
     """
-    Given `a[0], a[1], ..., a[k]` and `b[0], b[1], ..., b[j]`, find the index
-    of `b` which corresponds to each element of `a`.
+    Given `a[0], a[1], ..., a[k]` and `b[0], b[1], ..., b[j]`, match each element
+    of `a` to the corresponding element in `b`.
 
-    When `elements_must_match` is `True`, the default, `a` and `b` must
-    contain the same set of elements and `b[find_correspondence(a, b)]` will
-    equal `a`. Otherwise, return `-1` for elements in `a` having no match in
-    `b`.
+    When `all_must_match` is `True`, the default, `a` and `b` must contain the
+    same set of elements, and in that case, `b[find_correspondence(a, b)]`
+    will equal `a`. Otherwise, return `-1` for elements with no match in `b`.
 
     Args:
         a (np.arraylike): `kxn` array.
         b (np.arraylike): `jxn` array.
         atol (float): Match tolerance.
-        elements_must_match (bool): When `True`, `a` and `b` must contain the
+        all_must_match (bool): When `True`, `a` and `b` must contain the
             same elements.
         ret_unmatched_b (bool): When `True`, return a tuple which also contains
             the indices of `b` which were not matched.
@@ -39,7 +38,7 @@ def find_correspondence(
     """
     import numpy as np
 
-    if elements_must_match and len(a) != len(b):
+    if all_must_match and len(a) != len(b):
         raise ValueError("a and b do not contain the same number of elements")
 
     a_to_b = np.repeat(-1, len(a))
@@ -51,7 +50,7 @@ def find_correspondence(
             b_index = indices[0]
             b_matched[b_index] = True
             a_to_b[a_index] = b_index
-        elif elements_must_match:
+        elif all_must_match:
             raise ValueError(
                 "Couldn't find corresponding element in b for item {} in a".format(
                     a_index

--- a/entente/test_restore_correspondence.py
+++ b/entente/test_restore_correspondence.py
@@ -31,9 +31,7 @@ class TestRestoreCorrespondence(ExtraAssertions, unittest.TestCase):
         # https://stackoverflow.com/a/11649931/893113
         expected_v_old_to_new = np.argsort(v_new_to_old)
 
-        v_old_to_new = restore_correspondence(
-            working, self.test_mesh, progress=False
-        )
+        v_old_to_new = restore_correspondence(working, self.test_mesh, progress=False)
 
         np.testing.assert_array_equal(working.v, self.test_mesh.v)
         np.testing.assert_array_equal(working.f, self.test_mesh.f)

--- a/entente/test_restore_correspondence.py
+++ b/entente/test_restore_correspondence.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from .restore_correspondence import find_permutation, restore_correspondence
+from .restore_correspondence import find_correspondence, restore_correspondence
 from .testing import ExtraAssertions
 
 
@@ -12,30 +12,29 @@ class TestRestoreCorrespondence(ExtraAssertions, unittest.TestCase):
         # For performance.
         self.test_mesh.keep_vertices(np.arange(1000))
 
-    def test_find_permutation(self):
-        a = self.test_mesh.v
-        expected_permutation = np.random.permutation(len(a))
-        b = a[expected_permutation]
+    def test_find_correspondence(self):
+        b = self.test_mesh.v
+        expected_correspondence = np.random.permutation(len(b))
+        a = b[expected_correspondence]
 
-        result_permutation = find_permutation(a, b, progress=False)
+        correspondence = find_correspondence(a, b, progress=False)
 
-        np.testing.assert_array_equal(result_permutation, expected_permutation)
-        np.testing.assert_array_equal(a[result_permutation], b)
+        np.testing.assert_array_equal(correspondence, expected_correspondence)
+        np.testing.assert_array_equal(b[correspondence], a)
 
     def test_restore_correspondence(self):
         from .shuffle import shuffle_vertices
 
         working = self.test_mesh.copy_fv()
-        permutation = shuffle_vertices(working)
+        v_new_to_old = shuffle_vertices(working)
+        # Compute the inverse of the permutation.
+        # https://stackoverflow.com/a/11649931/893113
+        expected_v_old_to_new = np.argsort(v_new_to_old)
 
-        result_permutation = restore_correspondence(
+        v_old_to_new = restore_correspondence(
             working, self.test_mesh, progress=False
         )
 
         np.testing.assert_array_equal(working.v, self.test_mesh.v)
         np.testing.assert_array_equal(working.f, self.test_mesh.f)
-
-        # Compute the inverse of the permutation.
-        # https://stackoverflow.com/a/11649931/893113
-        v_old_to_new = np.argsort(permutation)
-        np.testing.assert_array_equal(result_permutation, v_old_to_new)
+        np.testing.assert_array_equal(v_old_to_new, expected_v_old_to_new)

--- a/entente/test_restore_correspondence.py
+++ b/entente/test_restore_correspondence.py
@@ -33,7 +33,7 @@ class TestRestoreCorrespondence(ExtraAssertions, unittest.TestCase):
         expected_unmatched_b = np.array([0])
 
         with self.assertRaises(ValueError):
-            res = find_correspondence(a, b, progress=False)
+            find_correspondence(a, b, progress=False)
 
         correspondence, unmatched_b = find_correspondence(
             a, b, all_must_match=False, ret_unmatched_b=True, progress=False

--- a/entente/test_restore_correspondence.py
+++ b/entente/test_restore_correspondence.py
@@ -28,6 +28,10 @@ class TestRestoreCorrespondence(ExtraAssertions, unittest.TestCase):
         a = b[expected_correspondence]
 
         a = np.vstack([a, np.array([1.0, 2.0, 3.0])])
+
+        with self.assertRaises(ValueError):
+            find_correspondence(a, b, progress=False)
+
         expected_correspondence = np.append(1 + expected_correspondence, np.array([-1]))
         b = np.vstack([np.array([3.0, 2.0, 1.0]), b])
         expected_unmatched_b = np.array([0])


### PR DESCRIPTION
- Allow unmatched entries and rename find_permutation() to find_correspondence()
- Flip semantics of a and b in find_correspondence()
- Allow unexact matching by default
- Improve documentation and clarity of tests