### PR TITLE
find_rigid_transform, find_rigid_rotation: Initial import from polliwog

### DIFF
--- a/entente/rigid_transform.py
+++ b/entente/rigid_transform.py
@@ -1,0 +1,101 @@
+import vg
+
+
+def find_rigid_transform(a, b, compute_scale=False, fail_in_degenerate_cases=True):
+    """
+    Args:
+        a: a Nx3 array of vertex locations
+        b: a Nx3 array of vertex locations
+        a and b are in correspondence -- we find a transformation such that the first
+        point in a will be moved to the location of the first point in b, etc.
+
+    Returns: (R,T) such that a.dot(R) + T ~= b
+        R is a 3x3 rotation matrix
+        T is a 1x3 translation vector
+
+    Based on Arun et al, "Least-squares fitting of two 3-D point sets," 1987.
+    See also Eggert et al, "Estimating 3-D rigid body transformations: a
+    comparison of four major algorithms," 1997.
+
+    If compute_scale is True, also computes and returns: (s, R,T) such that s*(R.dot(a))+T ~= b
+
+    In noisy cases, when there is a reflection, this algorithm can fail. In those cases the
+    right thing to do is to try a less noise sensitive algorithm like RANSAC. But if you want
+    a result anyway, even knowing that it might not be right, set fail_in_degenerate_cases=True.
+
+    """
+    import numpy as np
+
+    k = vg.shape.check(locals(), "a", (-1, 3))
+    vg.shape.check(locals(), "b", (k, 3))
+
+    a = a.T
+    b = b.T
+
+    a_mean = np.mean(a, axis=1)
+    b_mean = np.mean(b, axis=1)
+    a_centered = a - a_mean.reshape(-1, 1)
+    b_centered = b - b_mean.reshape(-1, 1)
+
+    c = a_centered.dot(b_centered.T)
+    u, s, v = np.linalg.svd(c, full_matrices=False)
+    v = v.T
+    R = v.dot(u.T)
+
+    if np.linalg.det(R) < 0:
+        if (
+            np.any(s == 0) or not fail_in_degenerate_cases
+        ):  # This is only valid in the noiseless case; see the paper
+            v[:, 2] = -v[:, 2]
+            R = v.dot(u.T)
+        else:
+            raise ValueError(
+                "find_rigid_transform found a reflection that it cannot recover from. Try RANSAC or something..."
+            )
+
+    if compute_scale:
+        scale = np.sum(s) / (np.linalg.norm(a_centered) ** 2)
+        T = (b_mean - scale * (R.dot(a_mean))).reshape(1, 3)
+        return scale, R.T, T
+    else:
+        T = (b_mean - R.dot(a_mean)).reshape(1, 3)
+        return R.T, T
+
+
+def find_rigid_rotation(a, b, allow_scaling=False):
+    """
+    Args:
+        a: a Nx3 array of vertex locations
+        b: a Nx3 array of vertex locations
+
+    Returns: R such that a.dot(R) ~= b
+
+    See link: http://en.wikipedia.org/wiki/Orthogonal_Procrustes_problem
+    """
+    import numpy as np
+
+    k = vg.shape.check(locals(), "a", (-1, 3))
+    vg.shape.check(locals(), "b", (k, 3))
+
+    a = a.T
+    b = b.T
+
+    if a.size == 3:
+        cx = np.cross(a.ravel(), b.ravel())
+        a = np.hstack([a.reshape(-1, 1), cx.reshape(-1, 1)])
+        b = np.hstack([b.reshape(-1, 1), cx.reshape(-1, 1)])
+
+    c = a.dot(b.T)
+    u, _, v = np.linalg.svd(c, full_matrices=False)
+    v = v.T
+    R = v.dot(u.T)
+
+    if np.linalg.det(R) < 0:
+        v[:, 2] = -v[:, 2]
+        R = v.dot(u.T)
+
+    if allow_scaling:
+        scalefactor = np.linalg.norm(b) / np.linalg.norm(a)
+        R = R * scalefactor
+
+    return R.T

--- a/entente/test_rigid_transform.py
+++ b/entente/test_rigid_transform.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+from polliwog import Box
+from polliwog.transform.rotation import euler
+from .rigid_transform import find_rigid_rotation, find_rigid_transform
+
+
+def test_rigid_transform_from_simple_translation():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    b = Box(origin=np.array([1.0, 2.0, 3.0]), size=np.array([1.0, 1.0, 1.0])).v
+    expected_R = np.eye(3)
+    expected_t = np.array([[1.0, 2.0, 3.0]])
+    R, t = find_rigid_transform(a, b)
+    np.testing.assert_array_almost_equal(a.dot(expected_R) + expected_t, b)
+    np.testing.assert_array_almost_equal(R, expected_R)
+    np.testing.assert_array_almost_equal(t, expected_t)
+
+
+def test_rigid_transform_from_simple_rotation():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    expected_R = euler([30, 15, 21])
+    expected_t = np.array([[0, 0, 0]])
+    b = a.dot(expected_R) + expected_t
+    R, t = find_rigid_transform(a, b)
+    np.testing.assert_array_almost_equal(a.dot(expected_R) + expected_t, b)
+    np.testing.assert_array_almost_equal(R, expected_R)
+    np.testing.assert_array_almost_equal(t, expected_t)
+
+
+def test_rigid_transform_from_rotation_and_translation():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    expected_R = euler([30, 15, 21])
+    expected_t = np.array([[1, 2, 3]])
+    b = a.dot(expected_R) + expected_t
+    R, t = find_rigid_transform(a, b)
+    np.testing.assert_array_almost_equal(a.dot(expected_R) + expected_t, b)
+    np.testing.assert_array_almost_equal(R, expected_R)
+    np.testing.assert_array_almost_equal(t, expected_t)
+
+
+def test_rigid_transform_from_rotation_translation_and_scale():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    expected_R = euler([30, 15, 21])
+    expected_t = np.array([[1, 2, 3]])
+    expected_scale = 1.7
+    b = expected_scale * a.dot(expected_R) + expected_t
+    s, R, t = find_rigid_transform(a, b, compute_scale=True)
+    np.testing.assert_array_almost_equal(s * a.dot(expected_R) + expected_t, b)
+    np.testing.assert_array_almost_equal(R, expected_R)
+    np.testing.assert_array_almost_equal(t, expected_t)
+    np.testing.assert_almost_equal(s, expected_scale)
+
+
+def test_rigid_transform_with_reflection():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    b = a * -1
+    with pytest.raises(ValueError):
+        find_rigid_transform(a, b)
+
+
+def test_rigid_transform_with_reflection_but_solve_anyway():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    b = a * -1
+    expected_R = np.eye(3)
+    expected_R[0][0] = expected_R[1][1] = -1
+    expected_t = np.array([[0.0, 0.0, -1.0]])
+    R, t = find_rigid_transform(a, b, fail_in_degenerate_cases=False)
+    np.testing.assert_array_almost_equal(R, expected_R)
+    np.testing.assert_array_almost_equal(t, expected_t)
+
+
+def test_rigid_rotation():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    expected_R = euler([30, 15, 21])
+    b = a.dot(expected_R)
+    R = find_rigid_rotation(a, b)
+    np.testing.assert_array_almost_equal(R, expected_R)
+
+
+def test_rigid_rotation_single_point():
+    a = np.array([[1, 2, 3]])
+    expected_R = euler([30, 15, 21])
+    b = a.dot(expected_R)
+    R = find_rigid_rotation(a, b)
+    # in this degenerate case, don't assert that we got the same
+    # rotation, just that it is a valid solution
+    np.testing.assert_array_almost_equal(a.dot(R), b)
+
+
+def test_rigid_rotation_with_reflection():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    b = a * -1
+    R = find_rigid_rotation(a, b)
+    expected_R = np.zeros((3, 3))
+    expected_R[0][0] = expected_R[1][2] = expected_R[2][1] = -1
+    np.testing.assert_array_almost_equal(R, expected_R)
+
+
+def test_rigid_rotation_with_scale():
+    a = Box(origin=np.array([0.0, 0.0, 0.0]), size=np.array([1.0, 1.0, 1.0])).v
+    expected_R = euler([30, 15, 21])
+    b = a.dot(expected_R)
+    R = find_rigid_rotation(a, b, allow_scaling=True)
+    np.testing.assert_array_almost_equal(R, expected_R)


### PR DESCRIPTION
These are being moved from polliwog as they are designed for vertex arrays in correspondence.

Depends on some unreleased changes in polliwog.