### PR TITLE
Landmarker: Improve error message when passing quad meshes

### DIFF
--- a/entente/landmarks/landmarker.py
+++ b/entente/landmarks/landmarker.py
@@ -23,6 +23,9 @@ class Landmarker(object):
     """
 
     def __init__(self, source_mesh, landmarks):
+        if not source_mesh.is_tri:
+            raise ValueError("Source mesh should be triangulated")
+
         self.source_mesh = source_mesh
         self.landmarks = landmarks
 
@@ -94,6 +97,9 @@ class Landmarker(object):
             dict: A mapping of landmark names to a np.ndarray with shape `3x1`.
         """
         from ..equality import have_same_topology
+
+        if not target.is_tri:
+            raise ValueError("Target mesh must be triangulated")
 
         if not have_same_topology(self.source_mesh, target):
             raise ValueError("Target mesh must have the same topology")

--- a/entente/landmarks/test_landmarker.py
+++ b/entente/landmarks/test_landmarker.py
@@ -1,4 +1,4 @@
-from lacecore import shapes
+from lacecore import shapes, Mesh
 import numpy as np
 import meshlab_pickedpoints
 import pytest
@@ -66,3 +66,16 @@ def test_landmarker_wrong_topology():
 
     with pytest.raises(ValueError, match="Target mesh must have the same topology"):
         landmarker.transfer_landmarks_onto(target_mesh)
+
+
+def test_landmarker_quad():
+    tri_mesh = shapes.cube(np.zeros(3), 1.0)
+    quad_mesh = Mesh(v=np.zeros((0, 3)), f=np.zeros((0, 4)))
+
+    with pytest.raises(ValueError, match="Source mesh should be triangulated"):
+        # Landmarks are empty; we don't get that far.
+        Landmarker(quad_mesh, {})
+
+    landmarker = Landmarker(tri_mesh, {})
+    with pytest.raises(ValueError, match="Target mesh must be triangulated"):
+        landmarker.transfer_landmarks_onto(quad_mesh)


### PR DESCRIPTION
This happens when you forget to pass `triangulate=True` to `lacecore.load_obj()`.